### PR TITLE
Add configuration of Kafka-topic based on runtime environment

### DIFF
--- a/src/main/kotlin/no/nav/tpts/mottak/App.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/App.kt
@@ -30,7 +30,7 @@ fun main() {
     LOG.info { "starting server" }
 
     flywayMigrate()
-    JoarkConsumer(createKafkaConsumer("teamdokumenthandtering.aapen-dok-journalfoering-q1")).also { it.start() }
+    JoarkConsumer(createKafkaConsumer()).also { it.start() }
 
     val issuer = System.getenv("AZURE_ISSUER")
     val jwksUri = System.getenv("AZURE_JWKS_URI")

--- a/src/main/kotlin/no/nav/tpts/mottak/Configuration.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/Configuration.kt
@@ -1,0 +1,11 @@
+package no.nav.tpts.mottak
+
+fun topicName(): String {
+    val clusterName = System.getenv("NAIS_CLUSTER_NAME")
+    LOG.info { "clusterName: $clusterName" }
+    return when (clusterName) {
+        "dev-gcp" -> "teamdokumenthandtering.aapen-dok-journalfoering-q1"
+        "prod-gcp" -> "teamdokumenthandtering.aapen-dok-journalfoering"
+        else -> "teamdokumenthandtering.aapen-dok-journalfoering-q1"
+    }
+}

--- a/src/main/kotlin/no/nav/tpts/mottak/joark/JoarkConsumer.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/joark/JoarkConsumer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
+import no.nav.tpts.mottak.topicName
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.Consumer
@@ -30,7 +31,7 @@ const val MAX_POLL_RECORDS = 50
 const val MAX_POLL_INTERVAL_MS = 5000
 private val POLL_TIMEOUT = Duration.ofSeconds(4)
 
-fun createKafkaConsumer(topicName: String): KafkaConsumer<String, GenericRecord> {
+fun createKafkaConsumer(): KafkaConsumer<String, GenericRecord> {
     return KafkaConsumer<String, GenericRecord>(
         Properties().also {
             it[ConsumerConfig.GROUP_ID_CONFIG] = "tpts-tiltakspenger-aiven-mottak-v3"
@@ -54,7 +55,7 @@ fun createKafkaConsumer(topicName: String): KafkaConsumer<String, GenericRecord>
             it[SchemaRegistryClientConfig.USER_INFO_CONFIG] =
                 System.getenv("KAFKA_SCHEMA_REGISTRY_USER") + ":" + System.getenv("KAFKA_SCHEMA_REGISTRY_PASSWORD")
         }
-    ).also { it.subscribe(listOf(topicName)) }
+    ).also { it.subscribe(listOf(topicName())) }
 }
 
 internal class JoarkConsumer(

--- a/src/test/kotlin/no/nav/tpts/mottak/ConfigurationTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/ConfigurationTest.kt
@@ -4,9 +4,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class ConfigurationTest {
-
     @Test
-    fun `foo`() {
+    fun `selects default topic-name when no system property is present`() {
         assertEquals("teamdokumenthandtering.aapen-dok-journalfoering-q1", topicName())
     }
 }

--- a/src/test/kotlin/no/nav/tpts/mottak/ConfigurationTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/ConfigurationTest.kt
@@ -1,0 +1,12 @@
+package no.nav.tpts.mottak
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class ConfigurationTest {
+
+    @Test
+    fun `foo`() {
+        assertEquals("teamdokumenthandtering.aapen-dok-journalfoering-q1", topicName())
+    }
+}


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Gjøre det mulig å skille på hvilken Kafka topic det skal lyttes på, basert på om man kjører i dev-gcp eller prod-gcp. Foreløpig enkel Config som kun håndterer Kafka-topic, men denne utvides nok etterhvert. YAGNI :-) 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Nope

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei