### PR TITLE
Add health check to Joark-consumer

### DIFF
--- a/src/main/kotlin/no/nav/tpts/mottak/health/HealthCheck.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/health/HealthCheck.kt
@@ -1,0 +1,10 @@
+package no.nav.tpts.mottak.health
+
+interface HealthCheck {
+    val name: String
+        get() = this.javaClass.simpleName
+
+    fun status(): HealthStatus
+}
+
+enum class HealthStatus { TILFREDS, ULYKKELIG }

--- a/src/main/kotlin/no/nav/tpts/mottak/health/HealthRoutes.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/health/HealthRoutes.kt
@@ -2,6 +2,8 @@ package no.nav.tpts.mottak.health
 
 import io.ktor.application.call
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.HttpStatusCode.Companion.ServiceUnavailable
 import io.ktor.response.respondText
 import io.ktor.response.respondTextWriter
 import io.ktor.routing.Route
@@ -9,19 +11,27 @@ import io.ktor.routing.get
 import io.ktor.routing.route
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
-import no.nav.tpts.mottak.LOG
+import mu.KotlinLogging
 
-fun Route.healthRoutes() {
+val LOG = KotlinLogging.logger { }
+
+fun Route.healthRoutes(healthChecks: List<HealthCheck>) {
     route("/metrics") {
         get {
-            call.respondTextWriter(ContentType.parse(TextFormat.CONTENT_TYPE_004), io.ktor.http.HttpStatusCode.OK) {
+            call.respondTextWriter(contentType = ContentType.parse(TextFormat.CONTENT_TYPE_004), status = OK) {
                 TextFormat.write004(this, CollectorRegistry.defaultRegistry.metricFamilySamples())
             }
         }
     }.also { LOG.info { "setting up endpoint /metrics" } }
     route("/isAlive") {
         get {
-            call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+            val failedHealthChecks = healthChecks.filter { it.status() == HealthStatus.ULYKKELIG }
+            if (failedHealthChecks.isNotEmpty()) {
+                LOG.warn { "Failed health checks: $failedHealthChecks" }
+                call.respondText(text = "DEAD", contentType = ContentType.Text.Plain, status = ServiceUnavailable)
+            } else {
+                call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+            }
         }
     }.also { LOG.info { "setting up endpoint /isAlive" } }
     route("/isReady") {

--- a/src/main/kotlin/no/nav/tpts/mottak/joark/JoarkConsumer.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/joark/JoarkConsumer.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
+import no.nav.tpts.mottak.health.HealthCheck
+import no.nav.tpts.mottak.health.HealthStatus
 import no.nav.tpts.mottak.topicName
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.CommonClientConfigs
@@ -61,12 +63,14 @@ fun createKafkaConsumer(): KafkaConsumer<String, GenericRecord> {
 internal class JoarkConsumer(
     private val consumer: Consumer<String, GenericRecord>,
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
-) {
+) : HealthCheck {
     private lateinit var job: Job
 
     init {
         Runtime.getRuntime().addShutdownHook(Thread(::shutdownHook))
     }
+
+    override fun status(): HealthStatus = if (job.isActive) HealthStatus.TILFREDS else HealthStatus.ULYKKELIG
 
     fun start() {
         LOG.info { "starting JoarkConsumer" }

--- a/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
@@ -1,0 +1,45 @@
+package no.nav.tpts.mottak.health
+
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.routing.routing
+import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.withTestApplication
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class HealthRoutesTest {
+
+    @Test
+    fun `empty health checks returns status ok`() {
+        withTestApplication({ routing { healthRoutes(emptyList()) } }) {
+            handleRequest(method = HttpMethod.Get, uri = "/isAlive").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+            }
+        }
+    }
+
+    @Test
+    fun `one happy health check returns ok`() {
+        val healthCheck = object : HealthCheck {
+            override fun status(): HealthStatus = HealthStatus.TILFREDS
+        }
+        withTestApplication({ routing { healthRoutes(listOf(healthCheck)) } }) {
+            handleRequest(method = HttpMethod.Get, uri = "/isAlive").apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+            }
+        }
+    }
+
+    @Test
+    fun `one unhappy health check returns not ok`() {
+        val healthCheck = object : HealthCheck {
+            override fun status(): HealthStatus = HealthStatus.ULYKKELIG
+        }
+        withTestApplication({ routing { healthRoutes(listOf(healthCheck)) } }) {
+            handleRequest(method = HttpMethod.Get, uri = "/isAlive").apply {
+                assertEquals(HttpStatusCode.ServiceUnavailable, response.status())
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/tpts/mottak/soknad/SoknadRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/soknad/SoknadRoutesTest.kt
@@ -163,7 +163,7 @@ class SoknadRoutesTest {
 
         withTestApplication({
             installAuth(jwkProvider)
-            appRoutes()
+            appRoutes(emptyList())
         }) {
             handleRequest(
                 HttpMethod.Get,


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
NAIS via (k8s) [tilbyr liveness](https://doc.nais.io/nais-application/application/#liveness). Om liveness feiler, vil det bli gjort en omstart av podden. Det funker nesten alltid. Vi må derfor vite når de ulike delene våre er friske eller syke. For Joark-lytteren vil det typisk være når jobben ikke lenger er aktiv

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Å bruke omstart som feilstrategi er ikke nødvendigvis en langsiktig løsning, men kan være et greit sted å starte

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [x] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

### 🤷‍♀ ️Hvor er det lurt å starte?
Nytt interface: `HealthCheck`

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei