### PR TITLE
Reuse Azure token if not expired

### DIFF
--- a/src/main/kotlin/no/nav/tpts/mottak/clients/AzureOauthClient.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/clients/AzureOauthClient.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.Serializable
 import no.nav.security.token.support.client.core.OAuth2GrantType
 import no.nav.security.token.support.client.core.OAuth2ParameterNames
 import no.nav.tpts.mottak.clients.HttpClient.client
-import java.time.LocalDateTime
 
 private val wellknownUrl = System.getenv("AZURE_APP_WELL_KNOWN_URL")
 private val clientSecret = System.getenv("AZURE_APP_CLIENT_SECRET")

--- a/src/main/kotlin/no/nav/tpts/mottak/clients/TokenCache.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/clients/TokenCache.kt
@@ -11,8 +11,6 @@ class TokenCache {
 
     fun update(accessToken: String, expiresIn: Long) {
         token = accessToken
-        expires = LocalDateTime.now().plusSeconds(
-            expiresIn.toLong()
-        )
+        expires = LocalDateTime.now().plusSeconds(expiresIn)
     }
 }

--- a/src/main/kotlin/no/nav/tpts/mottak/clients/TokenCache.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/clients/TokenCache.kt
@@ -1,0 +1,18 @@
+package no.nav.tpts.mottak.clients
+
+import java.time.LocalDateTime
+
+class TokenCache {
+    var token: String? = null
+        private set
+    private var expires: LocalDateTime? = null
+
+    fun isExpired(): Boolean = expires?.isBefore(LocalDateTime.now()) ?: true
+
+    fun update(accessToken: String, expiresIn: Long) {
+        token = accessToken
+        expires = LocalDateTime.now().plusSeconds(
+            expiresIn.toLong()
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tpts/mottak/clients/saf/SafClient.kt
+++ b/src/main/kotlin/no/nav/tpts/mottak/clients/saf/SafClient.kt
@@ -16,7 +16,7 @@ import no.nav.tpts.mottak.graphql.SafQuery.Variantformat.ORIGINAL
 import no.nav.tpts.mottak.graphql.journalpost
 
 object SafClient {
-    private val token = runBlocking { getToken().accessToken }
+    private val token = runBlocking { getToken() }
 
     suspend fun hentMetadataForJournalpost(journalpostId: String): JournalfortDokumentMetaData {
         val safResponse: SafQuery.Response = client.post(url = Url("{${getSafUrl()}/graphql}")) {

--- a/src/test/kotlin/no/nav/tpts/mottak/clients/TokenCacheTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/clients/TokenCacheTest.kt
@@ -9,8 +9,8 @@ class TokenCacheTest {
     fun `Should be expired if actually expired`() {
         val tokenCache = TokenCache()
         tokenCache.update(
-            "token",
-            -1
+            accessToken = "token",
+            expiresIn = -1
         )
         Assertions.assertEquals(true, tokenCache.isExpired())
     }
@@ -19,8 +19,8 @@ class TokenCacheTest {
     fun `Should not be expired initially`() {
         val tokenCache = TokenCache()
         tokenCache.update(
-            "token",
-            100
+            accessToken = "token",
+            expiresIn = 100
         )
         Assertions.assertEquals(false, tokenCache.isExpired())
     }
@@ -29,8 +29,8 @@ class TokenCacheTest {
     fun `should return cached token`() {
         val tokenCache = TokenCache()
         tokenCache.update(
-            "token",
-            100
+            accessToken = "token",
+            expiresIn = 100
         )
         Assertions.assertEquals("token", tokenCache.token)
     }

--- a/src/test/kotlin/no/nav/tpts/mottak/clients/TokenCacheTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/clients/TokenCacheTest.kt
@@ -1,0 +1,37 @@
+package no.nav.tpts.mottak.clients
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TokenCacheTest {
+
+    @Test
+    fun `Should be expired if actually expired`() {
+        val tokenCache = TokenCache()
+        tokenCache.update(
+            "token",
+            -1
+        )
+        Assertions.assertEquals(true, tokenCache.isExpired())
+    }
+
+    @Test
+    fun `Should not be expired initially`() {
+        val tokenCache = TokenCache()
+        tokenCache.update(
+            "token",
+            100
+        )
+        Assertions.assertEquals(false, tokenCache.isExpired())
+    }
+
+    @Test
+    fun `should return cached token`() {
+        val tokenCache = TokenCache()
+        tokenCache.update(
+            "token",
+            100
+        )
+        Assertions.assertEquals("token", tokenCache.token)
+    }
+}

--- a/src/test/kotlin/no/nav/tpts/mottak/saf/SafClientTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/saf/SafClientTest.kt
@@ -13,7 +13,6 @@ import io.mockk.mockkObject
 import kotlinx.coroutines.runBlocking
 import no.nav.tpts.mottak.clients.AzureOauthClient
 import no.nav.tpts.mottak.clients.HttpClient
-import no.nav.tpts.mottak.clients.OAuth2AccessTokenResponse
 import no.nav.tpts.mottak.clients.saf.SafClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -68,7 +67,7 @@ class SafClientTest {
     fun `skal lage request til saf graphql og parse responsen`() {
 
         mockkObject(AzureOauthClient)
-        coEvery { AzureOauthClient.getToken() } returns OAuth2AccessTokenResponse("TOKEN", "ACCESS_TOKEN", 123, 123)
+        coEvery { AzureOauthClient.getToken() } returns "TOKEN"
 
         val mockEngine = MockEngine {
             respond(


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

- Cache tokens fra Azure så lenge dem ikke er expired. Ifølge doc-en så oppgis expiresIn i sekunder https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow.  En annen endring er at AzureOauthClient bare eksponerer en String som er selve tokenet, ikke hele responsen. Token var det eneste som ble brukt.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [ ] Nei