### PR TITLE
Detekt config

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '28 3 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
     branches: [ main ]
 
-  jobs:
-    detekt:
-      runs-on: ubuntu-latest
+jobs:
+  detekt:
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: "checkout"
-          uses: actions/checkout@v2
+    steps:
+      - name: "checkout"
+        uses: actions/checkout@v2
 
-        - name: "detekt"
-          uses: natiginfo/action-detekt-all@1.19.0
-          with:
-            args: --fail-fast --config config/detekt.yml
+      - name: "detekt"
+        uses: natiginfo/action-detekt-all@1.19.0
+        with:
+          args: --fail-fast --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,103 +1,20 @@
-# This workflow performs a static analysis of your Kotlin source code using
-# Detekt.
-#
-# Scans are triggered:
-# 1. On every push to default and protected branches
-# 2. On every Pull Request targeting the default branch
-# 3. On a weekly schedule
-# 4. Manually, on demand, via the "workflow_dispatch" event
-#
-# The workflow should work with no modifications, but you might like to use a
-# later version of the Detekt CLI by modifing the $DETEKT_RELEASE_TAG
-# environment variable.
-name: Scan with Detekt
+name: detekt
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-     - cron: '28 3 * * 1'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+  jobs:
+    detekt:
+      runs-on: ubuntu-latest
 
-env:
-  # Release tag associated with version of Detekt to be installed
-  # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
-  DETEKT_RELEASE_TAG: v1.15.0
+      steps:
+        - name: "checkout"
+          uses: actions/checkout@v2
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  # This workflow contains a single job called "scan"
-  scan:
-    name: Scan
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
-
-    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
-    - name: Get Detekt download URL
-      id: detekt_info
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        DETEKT_DOWNLOAD_URL=$( gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
-          query getReleaseAssetDownloadUrl($tagName: String!) {
-            repository(name: "detekt", owner: "detekt") {
-              release(tagName: $tagName) {
-                releaseAssets(name: "detekt", first: 1) {
-                  nodes {
-                    downloadUrl
-                  }
-                }
-              }
-            }
-          }
-        ' | \
-        jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
-
-    # Sets up the detekt cli
-    - name: Setup Detekt
-      run: |
-        dest=$( mktemp -d )
-        curl --request GET \
-          --url ${{ steps.detekt_info.outputs.download_url }} \
-          --silent \
-          --location \
-          --output $dest/detekt
-        chmod a+x $dest/detekt
-        echo $dest >> $GITHUB_PATH
-
-    # Performs static analysis using Detekt
-    - name: Run Detekt
-      continue-on-error: true
-      run: |
-        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
-
-    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
-    # This is so we can easily map results onto their source files
-    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
-    - name: Make artifact location URIs relative
-      continue-on-error: true
-      run: |
-        echo "$(
-          jq \
-            --arg github_workspace ${{ github.workspace }} \
-            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
-            ${{ github.workspace }}/detekt.sarif.json
-        )" > ${{ github.workspace }}/detekt.sarif.json
-
-    # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v1
-      with:
-        # Path to SARIF file relative to the root of the repository
-        sarif_file: ${{ github.workspace }}/detekt.sarif.json
-        checkout_path: ${{ github.workspace }}
+        - name: "detekt"
+          uses: natiginfo/action-detekt-all@1.19.0
+          with:
+            args: --fail-fast --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -22,5 +22,3 @@ jobs:
 
       - name: "detekt"
         uses: natiginfo/action-detekt-all@1.19.0
-        with:
-          args: --fail-fast --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -14,4 +14,4 @@ jobs:
       - name: "detekt"
         uses: natiginfo/action-detekt-all@1.19.0
         with:
-          args: --build-upon-default-config --config config/detektiv.yml
+          args: --build-upon-default-config --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -5,9 +5,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '28 3 * * 1'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   detekt:
+    name: "Scan with Detekt"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -6,19 +6,19 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
-    - cron: '28 3 * * 1'
+     - cron: '28 3 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   detekt:
-    name: "Scan with Detekt"
+    name: Scan
     runs-on: ubuntu-latest
 
     steps:
       - name: "checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: "detekt"
         uses: natiginfo/action-detekt-all@1.19.0

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,103 +1,26 @@
-# This workflow performs a static analysis of your Kotlin source code using
-# Detekt.
-#
-# Scans are triggered:
-# 1. On every push to default and protected branches
-# 2. On every Pull Request targeting the default branch
-# 3. On a weekly schedule
-# 4. Manually, on demand, via the "workflow_dispatch" event
-#
-# The workflow should work with no modifications, but you might like to use a
-# later version of the Detekt CLI by modifing the $DETEKT_RELEASE_TAG
-# environment variable.
-name: Scan with Detekt
+name: detekt
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
   schedule:
-     - cron: '28 3 * * 1'
+    - cron: '28 3 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  # Release tag associated with version of Detekt to be installed
-  # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
-  DETEKT_RELEASE_TAG: v1.15.0
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "scan"
-  scan:
-    name: Scan
-    # The type of runner that the job will run on
+  detekt:
+    name: "Scan with Detekt"
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+      - name: "checkout"
+        uses: actions/checkout@v2
 
-    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
-    - name: Get Detekt download URL
-      id: detekt_info
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        DETEKT_DOWNLOAD_URL=$( gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
-          query getReleaseAssetDownloadUrl($tagName: String!) {
-            repository(name: "detekt", owner: "detekt") {
-              release(tagName: $tagName) {
-                releaseAssets(name: "detekt", first: 1) {
-                  nodes {
-                    downloadUrl
-                  }
-                }
-              }
-            }
-          }
-        ' | \
-        jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
-
-    # Sets up the detekt cli
-    - name: Setup Detekt
-      run: |
-        dest=$( mktemp -d )
-        curl --request GET \
-          --url ${{ steps.detekt_info.outputs.download_url }} \
-          --silent \
-          --location \
-          --output $dest/detekt
-        chmod a+x $dest/detekt
-        echo $dest >> $GITHUB_PATH
-
-    # Performs static analysis using Detekt
-    - name: Run Detekt
-      continue-on-error: true
-      run: |
-        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
-
-    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
-    # This is so we can easily map results onto their source files
-    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
-    - name: Make artifact location URIs relative
-      continue-on-error: true
-      run: |
-        echo "$(
-          jq \
-            --arg github_workspace ${{ github.workspace }} \
-            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
-            ${{ github.workspace }}/detekt.sarif.json
-        )" > ${{ github.workspace }}/detekt.sarif.json
-
-    # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v1
-      with:
-        # Path to SARIF file relative to the root of the repository
-        sarif_file: ${{ github.workspace }}/detekt.sarif.json
-        checkout_path: ${{ github.workspace }}
+      - name: "detekt"
+        uses: natiginfo/action-detekt-all@1.19.0
+        with:
+          args: --fail-fast --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -14,4 +14,4 @@ jobs:
       - name: "detekt"
         uses: natiginfo/action-detekt-all@1.19.0
         with:
-          args: --fail-fast --config config/detekt.yml
+          args: --build-upon-default-config --config config/detekt.yml

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,6 +1,15 @@
 name: detekt
 
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '28 3 * * 1'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   detekt:

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,15 +1,6 @@
 name: detekt
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  schedule:
-    - cron: '28 3 * * 1'
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: push
 
 jobs:
   detekt:

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,6 +1,19 @@
-name: detekt
+# This workflow performs a static analysis of your Kotlin source code using
+# Detekt.
+#
+# Scans are triggered:
+# 1. On every push to default and protected branches
+# 2. On every Pull Request targeting the default branch
+# 3. On a weekly schedule
+# 4. Manually, on demand, via the "workflow_dispatch" event
+#
+# The workflow should work with no modifications, but you might like to use a
+# later version of the Detekt CLI by modifing the $DETEKT_RELEASE_TAG
+# environment variable.
+name: Scan with Detekt
 
 on:
+  # Triggers the workflow on push or pull request events but only for default and protected branches
   push:
     branches: [ main ]
   pull_request:
@@ -11,14 +24,80 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  # Release tag associated with version of Detekt to be installed
+  # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
+  DETEKT_RELEASE_TAG: v1.15.0
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  detekt:
+  # This workflow contains a single job called "scan"
+  scan:
     name: Scan
+    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: "checkout"
-        uses: actions/checkout@v3
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
 
-      - name: "detekt"
-        uses: natiginfo/action-detekt-all@1.19.0
+    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
+    - name: Get Detekt download URL
+      id: detekt_info
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        DETEKT_DOWNLOAD_URL=$( gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
+          query getReleaseAssetDownloadUrl($tagName: String!) {
+            repository(name: "detekt", owner: "detekt") {
+              release(tagName: $tagName) {
+                releaseAssets(name: "detekt", first: 1) {
+                  nodes {
+                    downloadUrl
+                  }
+                }
+              }
+            }
+          }
+        ' | \
+        jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
+        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
+
+    # Sets up the detekt cli
+    - name: Setup Detekt
+      run: |
+        dest=$( mktemp -d )
+        curl --request GET \
+          --url ${{ steps.detekt_info.outputs.download_url }} \
+          --silent \
+          --location \
+          --output $dest/detekt
+        chmod a+x $dest/detekt
+        echo $dest >> $GITHUB_PATH
+
+    # Performs static analysis using Detekt
+    - name: Run Detekt
+      continue-on-error: true
+      run: |
+        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+
+    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
+    # This is so we can easily map results onto their source files
+    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
+    - name: Make artifact location URIs relative
+      continue-on-error: true
+      run: |
+        echo "$(
+          jq \
+            --arg github_workspace ${{ github.workspace }} \
+            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
+            ${{ github.workspace }}/detekt.sarif.json
+        )" > ${{ github.workspace }}/detekt.sarif.json
+
+    # Uploads results to GitHub repository using the upload-sarif action
+    - uses: github/codeql-action/upload-sarif@v1
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: ${{ github.workspace }}/detekt.sarif.json
+        checkout_path: ${{ github.workspace }}

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -14,4 +14,4 @@ jobs:
       - name: "detekt"
         uses: natiginfo/action-detekt-all@1.19.0
         with:
-          args: --build-upon-default-config --config config/detekt.yml
+          args: --build-upon-default-config --config config/detektiv.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,12 @@ java {
     targetCompatibility = javaVersion
 }
 
+detekt {
+    buildUponDefaultConfig = true
+    allRules = false
+    config = files("$projectDir/config/detekt.yml")
+}
+
 // https://github.com/ben-manes/gradle-versions-plugin
 fun isNonStable(version: String): Boolean {
     val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { version.toUpperCase().contains(it) }

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,0 +1,10 @@
+style:
+  WildcardImport:
+    active: false
+  MaxLineLength:
+    maxLineLength: 160
+formatting:
+  MaximumLineLength:
+    maxLineLength: 160
+  NoWildcardImports:
+    active: false

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,10 +1,6 @@
 style:
   WildcardImport:
     active: false
-  MaxLineLength:
-    maxLineLength: 160
 formatting:
-  MaximumLineLength:
-    maxLineLength: 160
   NoWildcardImports:
     active: false

--- a/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class HealthRoutesTest {
+    private val foo = "fdjksf"
 
     @Test
     fun `empty health checks returns status ok`() {

--- a/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/health/HealthRoutesTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class HealthRoutesTest {
-    private val foo = "fdjksf"
 
     @Test
     fun `empty health checks returns status ok`() {


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
Jeg synes Detekt er et bra verktøy, men litt plagsomt. Særlig er det to regler som plager meg: at jeg ikke kan ha wildcard imports og at linjelengden er satt til 120. Her er et forslag som fjerner begrensningen på wildcard imports og øker linjelengden til 160.

### 🔎️ Er det noe spesielt du ønsker å fremheve?
Wildcard imports: spiller egentlig ingen rolle for meg om det skal være tillatt eller ei. Problemet er at IntelliJ sitt default regelsett tillater det, mens Detekt ikke gjør det.

Dersom vi velger å gjøre denne endringen, er det nyttig å fortelle Detekt plugin i IntelliJ også at det nå finnes en config-fil. 

Preferences -> Tools -> Detekt -> Configuration Files: /Users/pj/dev/tpts-tiltakspenger-mottak/config/detekt.yml

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [ ] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_
det ikke er noe å teste

### 🤷‍♀ ️Hvor er det lurt å starte?
alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei, ikke nødvendig