### PR TITLE
Split kvp-intro tests into own tests

### DIFF
--- a/src/test/kotlin/no/nav/tpts/mottak/joark/JoarkSoknadTest.kt
+++ b/src/test/kotlin/no/nav/tpts/mottak/joark/JoarkSoknadTest.kt
@@ -46,8 +46,6 @@ internal class JoarkSoknadTest {
             assertEquals(LocalDate.parse("2022-03-31"), it.brukerRegistrertSluttDato)
             assertNull(it.systemRegistrertStartDato)
             assertNull(it.systemRegistrertSluttDato)
-            assertEquals(false, it.deltarKvp)
-            assertEquals(false, it.deltarIntroduksjonsprogrammet)
         }
     }
 
@@ -64,9 +62,23 @@ internal class JoarkSoknadTest {
     }
 
     @Test
+    fun `soker som IKKE deltar på intro should have false in deltarIntroduksjonsprogrammet field`() {
+        val soknadJson = this::class.java.classLoader.getResource("soknad_uten_tiltak_fra_arena.json")!!.readText()
+        val soknad = Soknad.fromJson(soknadJson)
+        assertEquals(false, soknad.deltarIntroduksjonsprogrammet)
+    }
+
+    @Test
     fun `soker som deltar på kvp should have true in deltarKvp field`() {
         val soknad = Soknad.fromJson(File("src/test/resources/soknad_deltar_kvp.json").readText())
         assertEquals(true, soknad.deltarKvp)
+    }
+
+    @Test
+    fun `soker som IKKE deltar på kvp should have false in deltarKvp field`() {
+        val soknadJson = this::class.java.classLoader.getResource("soknad_uten_tiltak_fra_arena.json")!!.readText()
+        val soknad = Soknad.fromJson(soknadJson)
+        assertEquals(false, soknad.deltarKvp)
     }
 
     @Test


### PR DESCRIPTION
### 💰 Hva forsøker du å løse i denne PR'en
_Skriv 1 eller 2 setninger om hvilken funksjonell endring som blir implementert._

Flytter "negative" kvp og intro tester inn i egne tester. Nå ligger de under dato-testen 

### 🔎️ Er det noe spesielt du ønsker å fremheve?
_Er det noe du er bekymret eller usikker på? Beskriv det gjerne her._

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config eller sql endringer. Isåfall, husk manuell deploy til miljø for å verifisere endringene.
- [x] Jeg har skrevet tester. Hvis du ikke har skrevet tester, beskriv hvorfor under 👇

_Jeg har ikke skrevet tester fordi:_


### 🤷‍♀ ️Hvor er det lurt å starte?
_F.eks. commit for commit, alt i ett?_
Alt i ett

### 💬 Ønsker du en muntlig gjennomgang?
- [ ] Ja
- [x] Nei